### PR TITLE
Fix missing _time col name in output of predictLinear

### DIFF
--- a/query/functions/predict_linear.go
+++ b/query/functions/predict_linear.go
@@ -161,7 +161,7 @@ func (t *PredictLinearTransformation) Process(id execute.DatasetID, tbl query.Ta
 	}
 	execute.AddTableKeyCols(tbl.Key(), builder)
 	valueIdx := builder.AddCol(query.ColMeta{
-		Label: t.spec.TimeDst,
+		Label: t.spec.ValueLabel,
 		Type:  query.TTime,
 	})
 	valueIdy := builder.AddCol(query.ColMeta{

--- a/query/functions/testdata/predict_linear.out.csv
+++ b/query/functions/testdata/predict_linear.out.csv
@@ -1,5 +1,5 @@
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,double
 #group,false,false,true,false,false
 #default,_result,,,,
-,result,table,_stop,,_value
+,result,table,_stop,_time,_value
 ,,0,2018-08-10T09:40:00Z,2018-08-19T09:30:00.011552Z,10


### PR DESCRIPTION
Fix issue that predictLinear does not provide _time column name in output